### PR TITLE
remove deprecated fs.existsSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ module.exports = function (filepath, options) {
   
   if (!filepath) return false;
   
-  var root  = options.root;
+  var root = options.root;
   var fullpath = (root) ? path.join(root, filepath) : filepath;
   
-  
-  if (!fs.existsSync(fullpath)) return false;
-  if (!fs.statSync(fullpath).isFile()) return false;
-  
-  return true;
+  try {
+    return fs.statSync(fullpath).isFile();
+  } catch (e) {
+    return false;
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-exists",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Check if filepath exists and is a file",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
`try`/`catch` added as node will throw an error if the file does not exist.

https://nodejs.org/api/fs.html#fs_fs_existssync_path

<img width="500" alt="screen shot 2015-10-25 at 11 35 47" src="https://cloud.githubusercontent.com/assets/3459542/10716363/a5d21810-7b0c-11e5-9a36-468dbf43dbfe.png">

Will resolve https://github.com/scottcorgan/file-exists/issues/1
