### PR TITLE
Fix async non-existing file

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ function fileExists (filepath, options, done = function () {}) {
 
   fs.stat(fullPath(filepath, options), (err, stats) => {
     if (err) {
-      return done(err)
+      return err.code === "ENOENT" ?
+        done(null, false) :
+        done(err)
     }
 
     done(null, stats.isFile())

--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ function fileExists (filepath, options, done = function () {}) {
 
   fs.stat(fullPath(filepath, options), (err, stats) => {
     if (err) {
-      return err.code === 'ENOENT' ?
-        done(null, false) :
-        done(err)
+      return err.code === 'ENOENT'
+        ? done(null, false)
+        : done(err)
     }
 
     done(null, stats.isFile())

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function fileExists (filepath, options, done = function () {}) {
 
   fs.stat(fullPath(filepath, options), (err, stats) => {
     if (err) {
-      return err.code === "ENOENT" ?
+      return err.code === 'ENOENT' ?
         done(null, false) :
         done(err)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,13 @@ test('async', t => {
         t.notOk(exists, 'directory is not a file')
         done()
       })
+    },
+    done => {
+      fileExists('not.here', (err, exists) => {
+        t.notOk(err, 'non-existing file doesn\'t throw')
+        t.notOk(exists, 'non-existing file doesn\'t exist')
+        done()
+      })
     }
   ], err => {
     rmdir('.tmp', () => t.end())
@@ -40,6 +47,7 @@ test('sync', t => {
   t.ok(fileExists.sync('.tmp/index.html'), 'file does exist')
   t.ok(fileExists.sync('/index.html', {root: '.tmp'}), 'file exists in given root directory')
   t.notOk(fileExists.sync('.tmp'), 'directory is not a file')
+  t.notOk(fileExists.sync('not.here'), 'non-existing file doesn\'t exist')
 
   rmdir('.tmp', () => t.end())
 })


### PR DESCRIPTION
Previously, as in #7, non-existing files threw errors in async mode. This PR addresses that issue by checking for `ENOENT` error codes when using `fs.stat()`.